### PR TITLE
Issue #9 Separate Security key to .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 __pycache__/
 local_settings.py
 
+SECURITY_KEY.env
 .env
 db.sqlite3
 bin/

--- a/SECRET_KEY.env
+++ b/SECRET_KEY.env
@@ -1,1 +1,1 @@
-SECRET_KEY='youtube_downloader_secret_key_gsoc_2020'
+SECRET_KEY='SA'

--- a/SECRET_KEY.env
+++ b/SECRET_KEY.env
@@ -1,0 +1,1 @@
+SECRET_KEY='youtube_downloader_secret_key_gsoc_2020'

--- a/downloader/settings.py
+++ b/downloader/settings.py
@@ -11,6 +11,17 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+import environ
+
+# Project Base Paths
+# project_root/your_app/settings.py - 2 = project_root/
+ROOT_DIR = environ.Path(__file__) - 2
+
+env = environ.Env()
+
+env_file = ROOT_DIR('SECRET_KEY.env')
+env.read_env(env_file)
+SECRET_KEY = env.str('SECRET_KEY')
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -18,9 +29,6 @@ TEMPLATE_DIR = os.path.join(BASE_DIR, '')
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "SA"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==3.0.0
 python-decouple==3.3
 django-embed-video==0.6
+django-environ 


### PR DESCRIPTION
Added django environ to requirements.txt to use import environ in settings.py 
added code to read security key from SECURITY_KEY.env and created a .env file in root folder and added the initial security key in it.